### PR TITLE
Fix wrong note in GUI when reading from config

### DIFF
--- a/morph/preferencesDialog.py
+++ b/morph/preferencesDialog.py
@@ -157,9 +157,9 @@ class PreferencesDialog( QDialog ):
         active = 0
         modelComboBox.addItem("All note types")
         for i, model in enumerate(mw.col.models.allNames()):
-            if model == data['Type']: active = i
+            if model == data['Type']: active = i + 1
             modelComboBox.addItem(model)
-        modelComboBox.setCurrentIndex(active + 1)
+        modelComboBox.setCurrentIndex(active)
 
         active = 1
         morphemizerComboBox = QComboBox()


### PR DESCRIPTION
I noticed that, when trying to set 'All note types' in the Note Filter
dialog, it would always jump back to the first *actual* note type
upon reloading the dialog. The data was saved correctly into the json
config, however. Turns out it was just a simple +1 error. :)