### PR TITLE
Fix cfg() instead of jcfg() for field usage

### DIFF
--- a/morph/extractMorphemes.py
+++ b/morph/extractMorphemes.py
@@ -2,8 +2,8 @@
 import os
 
 from morphemes import AnkiDeck, MorphDb, getMorphemes, ms2str
-from morphemizer import getMorphemizerForNote
-from util import addBrowserSelectionCmd, cfg, cfg1, mw, infoMsg, QFileDialog
+from morphemizer import getMorphemizerForFilter
+from util import addBrowserSelectionCmd, cfg, cfg1, mw, getFilter, infoMsg, QFileDialog
 
 def pre( b ):
     from util import dbsPath # not defined until late, so don't import at top of module
@@ -13,10 +13,14 @@ def pre( b ):
 
 def per( st, n ):
     mats = mw.col.db.list( 'select ivl from cards where nid = :nid', nid=n.id )
-    for f in cfg( n.mid, None, 'morph_fields' ):
-        ms = getMorphemes(getMorphemizerForNote(n), n[ f ])
-        loc = AnkiDeck( n.id, f, n[ f ], n.guid, mats )
-        st['morphDb'].addMsL( ms, loc )
+    notecfg = getFilter(n)
+    if notecfg is None: return st
+    morphemizer = getMorphemizerForFilter(notecfg)
+    for f in notecfg['Fields']:
+        ms = getMorphemes(morphemizer, n[f])
+        loc = AnkiDeck(n.id, f, n[f], n.guid, mats)
+        st['morphDb'].addMsl(ms, loc)
+
     return st
 
 def post( st ):

--- a/morph/massTagger.py
+++ b/morph/massTagger.py
@@ -1,7 +1,7 @@
 #-*- coding: utf-8 -*-
 from morphemes import getMorphemes, MorphDb
-from morphemizer import getMorphemizerForNote
-from util import addBrowserSelectionCmd, cfg, cfg1, infoMsg, QInputDialog, QFileDialog, QLineEdit
+from morphemizer import getMorphemizerForFilter
+from util import addBrowserSelectionCmd, cfg, cfg1, getFilter, infoMsg, QInputDialog, QFileDialog, QLineEdit
 import util
 
 def pre( b ): # :: Browser -> State
@@ -15,11 +15,15 @@ def pre( b ): # :: Browser -> State
 def per( st, n ): # :: State -> Note -> State
     #n.delTag( st['tags'] ) # clear tags if they already exist?
 
-    for field in cfg( n.mid, None, 'morph_fields' ):
-        for m in getMorphemes(getMorphemizerForNote(n), n[ field ]):
-            if m in st['db'].db:
-                n.addTag( st['tags'] )
-                break
+    notecfg = getFilter(n)
+    if notecfg is None: return st
+    morphemizer = getMorphemizerForFilter(notecfg)
+    if notecfg is None: return st
+    for m in getMorphemes(morphemizer, notecfg['Fields']):
+        if m in st['db'].db:
+            n.addTag(st['tags'])
+            break
+
     n.flush()
     return st
 

--- a/morph/viewMorphemes.py
+++ b/morph/viewMorphemes.py
@@ -1,17 +1,22 @@
 #-*- coding: utf-8 -*-
 from morphemes import getMorphemes, ms2str
-from morphemizer import getMorphemizerForNote
-from util import addBrowserSelectionCmd, cfg, cfg1, infoMsg
+from morphemizer import getMorphemizerForFilter
+from util import addBrowserSelectionCmd, cfg, cfg1, getFilter, infoMsg
 
 def pre( b ): return { 'txt':'', 'morphemizer': None }
 
 def per( st, n ):
-    st['morphemizer'] = getMorphemizerForNote(n)
-    for f in cfg( n.mid, None, 'morph_fields' ):
+    notecfg = getFilter(n)
+    if notecfg is None: return st
+    st['morphemizer'] = getMorphemizerForFilter(notecfg)
+    for f in notecfg['Fields']:
         st['txt'] += n[ f ] + '  '
     return st
 
 def post( st ):
+    if st['txt'] == '':
+        infoMsg('----- No morphemes, check your filters -----')
+        return
     ms = getMorphemes(st['morphemizer'], st['txt'])
     s = ms2str( ms )
     infoMsg( '----- All -----\n' + s )


### PR DESCRIPTION
Three of the commands in the browser window were still using the old
location for the MorphMan fields (`morph_fields` from `cfg()`). This
commit changes those commands to use the filters in `jcfg()` instead.

It also fixes the errors occuring `massTagger.per()` and
`viewMorphemes.per()` for the case where no notes in the current
selection were in the DB/had correct filters in `jcfg()`.